### PR TITLE
Updated print statements to be compatible with python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ def generate_random(n_values, min_value, max_value):
         A list containing 'n_values' random values in the range
         between 'min_value' and 'max_value'
     """
-    return random.sample(xrange(min_value, max_value), n_values)
+    return sample(range(min_value, max_value), n_values)
 
 # Generate some random data
 data = generate_random(1000, 1, 10000)
@@ -62,18 +62,18 @@ data = generate_random(1000, 1, 10000)
 confidence = 0.95
 iterations = 1000
 sample_size = 1.0
-statistic = numpy.mean
+statistic = np.mean
 lower, upper = bootstrap(data,
-                         confidence=confidence,
-                         iterations=iterations,
-                         sample_size=sample_size,
-                         statistic=statistic)
-print('Performed %d iterations (each with %.1f%% original sample length)' %
-      (iterations, sample_size * 100))
-print('%.1f%% confidence interval (%s):' %
-      (confidence * 100, statistic.__name__))
+                            confidence=confidence,
+                            iterations=iterations,
+                            sample_size=sample_size,
+                            statistic=statistic)
 
-print 'lower: %.1f' % lower
-print 'upper: %.1f' % upper
-print 'observed: %.1f' % numpy.mean(data)
+print('Performed {} iterations (each with {}% original sample length)'.format(
+    iterations, sample_size*100))
+print('{:3.1f}% confidence interval ({:s}):'.format(
+    confidence*100, statistic.__name__))
+print('lower: {:.1f}'.format(lower))
+print('upper: {:.1f}'.format(upper))
+print('observed: {:.1f}'.format(np.mean(data)))
 ```

--- a/pybootstrap/__init__.py
+++ b/pybootstrap/__init__.py
@@ -80,7 +80,7 @@ def test():
             A list containing 'n_values' random values in the range
             between 'min_value' and 'max_value'
         """
-        return random.sample(xrange(min_value, max_value), n_values)
+        return random.sample(range(min_value, max_value), n_values)
 
     # Generate some random data
     data = generate_random(1000, 1, 10000)
@@ -98,10 +98,10 @@ def test():
           (iterations, sample_size * 100))
     print('%.1f%% confidence interval (%s):' %
           (confidence * 100, statistic.__name__))
-
-    print 'lower: %.1f' % lower
+    print'lower: %.1f' % lower
     print 'upper: %.1f' % upper
     print 'observed: %.1f' % numpy.mean(data)
+
 
 if __name__ == '__main__':
     test()

--- a/pybootstrap/__init__.py
+++ b/pybootstrap/__init__.py
@@ -28,6 +28,7 @@ from random import sample
 import numpy as np
 from sklearn.utils import resample
 
+
 def bootstrap(dataset, confidence=0.95, iterations=10000,
               sample_size=1.0, statistic=np.mean):
     """
@@ -63,6 +64,7 @@ def bootstrap(dataset, confidence=0.95, iterations=10000,
 
     return (lval, uval)
 
+
 def test():
     """
     A simple test with randomly generated data
@@ -93,17 +95,15 @@ def test():
                              confidence=confidence,
                              iterations=iterations,
                              sample_size=sample_size,
- 
                              statistic=statistic)
-    
-    
-    print('Performed %d iterations (each with %.1f%% original sample length)' %
-          (iterations, sample_size * 100))
-    print('%.1f%% confidence interval (%s):' %
-          (confidence * 100, statistic.__name__))
-    print'lower: %.1f' % lower
-    print 'upper: %.1f' % upper
-    print 'observed: %.1f' % numpy.mean(data)
+
+    print('Performed {} iterations (each with {}% original sample length)'.format(
+        iterations, sample_size*100))
+    print('{:3.1f}% confidence interval ({:s}):'.format(
+        confidence*100, statistic.__name__))
+    print('lower: {:.1f}'.format(lower))
+    print('upper: {:.1f}'.format(upper))
+    print('observed: {:.1f}'.format(np.mean(data)))
 
 
 if __name__ == '__main__':

--- a/pybootstrap/__init__.py
+++ b/pybootstrap/__init__.py
@@ -24,12 +24,12 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-import random
-import numpy
-import sklearn
+from random import sample
+import numpy as np
+from sklearn.utils import resample
 
 def bootstrap(dataset, confidence=0.95, iterations=10000,
-              sample_size=1.0, statistic=numpy.mean):
+              sample_size=1.0, statistic=np.mean):
     """
     Bootstrap the confidence intervals for a given sample of a population
     and a statistic.
@@ -51,15 +51,15 @@ def bootstrap(dataset, confidence=0.95, iterations=10000,
 
     for _ in range(iterations):
         # Sample (with replacement) from the given dataset
-        sample = sklearn.utils.resample(dataset, n_samples=n_size)
+        sample = resample(dataset, n_samples=n_size)
         # Calculate user-defined statistic and store it
         stat = statistic(sample)
         stats.append(stat)
 
     # Sort the array of per-sample statistics and cut off ends
     ostats = sorted(stats)
-    lval = numpy.percentile(ostats, ((1 - confidence) / 2) * 100)
-    uval = numpy.percentile(ostats, (confidence + ((1 - confidence) / 2)) * 100)
+    lval = np.percentile(ostats, ((1 - confidence) / 2) * 100)
+    uval = np.percentile(ostats, (confidence + ((1 - confidence) / 2)) * 100)
 
     return (lval, uval)
 
@@ -80,7 +80,7 @@ def test():
             A list containing 'n_values' random values in the range
             between 'min_value' and 'max_value'
         """
-        return random.sample(range(min_value, max_value), n_values)
+        return sample(range(min_value, max_value), n_values)
 
     # Generate some random data
     data = generate_random(1000, 1, 10000)
@@ -88,12 +88,15 @@ def test():
     confidence = 0.95
     iterations = 1000
     sample_size = 1.0
-    statistic = numpy.mean
+    statistic = np.mean
     lower, upper = bootstrap(data,
                              confidence=confidence,
                              iterations=iterations,
                              sample_size=sample_size,
+ 
                              statistic=statistic)
+    
+    
     print('Performed %d iterations (each with %.1f%% original sample length)' %
           (iterations, sample_size * 100))
     print('%.1f%% confidence interval (%s):' %


### PR DESCRIPTION
As stated in #1 the module did not work with python 3.

The print statements at the end of the test-function were the reason for this.

I used the new print format to fix this.

I also changed the imports to be more inline with convention: i.e import numpy as np